### PR TITLE
Adds MIT license reference to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,6 @@
     "jiti": "^2.4.2",
     "commander": "^13.1.0",
     "@sinclair/typebox-codegen": "^0.10.5"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
This is so that it shows on npm