### PR TITLE
@sinclair/typebox is not a dev dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0-dev",
       "license": "MIT",
       "dependencies": {
+        "@sinclair/typebox": "^0.34.20",
         "@sinclair/typebox-codegen": "^0.10.5",
         "commander": "^13.1.0",
         "jiti": "^2.4.2"
@@ -18,7 +19,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
-        "@sinclair/typebox": "^0.34.16",
         "@types/eslint": "^9.6.1",
         "@types/node": "^22.10.10",
         "eslint": "^9.19.0",
@@ -990,7 +990,6 @@
       "version": "0.34.20",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.20.tgz",
       "integrity": "sha512-rVNFD9dFMzZgnuv0LZHZHIjS3R5nSOWIQaxP7GrcgsA3yf/tCH5xZ7zJkxWCee4EXfiTuQWbtcBcQMsd4AiCzg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox-codegen": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "type": "module",
   "devDependencies": {
     "@eslint/js": "^9.19.0",
-    "@sinclair/typebox": "^0.34.16",
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.10.10",
     "eslint": "^9.19.0",
@@ -47,9 +46,10 @@
     "dist"
   ],
   "dependencies": {
-    "jiti": "^2.4.2",
+    "@sinclair/typebox": "^0.34.20",
+    "@sinclair/typebox-codegen": "^0.10.5",
     "commander": "^13.1.0",
-    "@sinclair/typebox-codegen": "^0.10.5"
+    "jiti": "^2.4.2"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
`@sinclair/typebox` is a direct dependency as its used on runtime. It was previously inherently included through an indirect dependency with `typebox-codegen`, but for correctness it should be fixed here.